### PR TITLE
feat: 이력 상세 조회 api 구현 (#32)

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogDiffController.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogDiffController.java
@@ -1,4 +1,26 @@
 package com.team1.hrbank.domain.changelog.controller;
 
+import com.team1.hrbank.domain.changelog.dto.data.ChangeLogDiffDto;
+import com.team1.hrbank.domain.changelog.service.ChangeLogDiffService;
+import com.team1.hrbank.domain.changelog.service.ChangeLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/change-logs")
 public class ChangeLogDiffController {
+    private final ChangeLogDiffService changeLogDiffService;
+
+    @GetMapping("/{changeLogId}/diffs")
+    public ResponseEntity<List<ChangeLogDiffDto>> getDiffs(@PathVariable Long changeLogId) {
+        List<ChangeLogDiffDto> diffs = changeLogDiffService.findAllByChangeLogId(changeLogId);
+        return ResponseEntity.ok(diffs);
+    }
 }

--- a/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogDiffController.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogDiffController.java
@@ -2,7 +2,6 @@ package com.team1.hrbank.domain.changelog.controller;
 
 import com.team1.hrbank.domain.changelog.dto.data.ChangeLogDiffDto;
 import com.team1.hrbank.domain.changelog.service.ChangeLogDiffService;
-import com.team1.hrbank.domain.changelog.service.ChangeLogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/change-logs")
 public class ChangeLogDiffController {
+
     private final ChangeLogDiffService changeLogDiffService;
 
     @GetMapping("/{changeLogId}/diffs")

--- a/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/change-logs")
 public class ChangeLogListController {
+
     private final ChangeLogService changeLogService;
 
     @GetMapping

--- a/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
@@ -5,6 +5,7 @@ import com.team1.hrbank.domain.changelog.dto.response.ChangeLogSearchResponse;
 import com.team1.hrbank.domain.changelog.service.ChangeLogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +17,7 @@ public class ChangeLogListController {
 
     private final ChangeLogService changeLogService;
 
+    @GetMapping
     public ResponseEntity<ChangeLogSearchResponse> getChangeLogs(
             @ModelAttribute ChangeLogSearchRequest changeLogSearchRequest
     ) {

--- a/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/controller/ChangeLogListController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/change-logs")
 public class ChangeLogListController {
-
     private final ChangeLogService changeLogService;
 
     @GetMapping

--- a/src/main/java/com/team1/hrbank/domain/changelog/mapper/ChangeLogDiffMapper.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/mapper/ChangeLogDiffMapper.java
@@ -1,9 +1,11 @@
 package com.team1.hrbank.domain.changelog.mapper;
 
+import com.team1.hrbank.domain.changelog.dto.data.ChangeLogDiffDto;
 import com.team1.hrbank.domain.changelog.entity.ChangeLog;
 import com.team1.hrbank.domain.changelog.entity.ChangeLogDiff;
 import com.team1.hrbank.domain.employee.entity.Employee;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -14,6 +16,10 @@ import java.util.Objects;
 public interface ChangeLogDiffMapper {
 
     String EMPTY = "-";
+
+    @Mapping(source = "beforeValue", target = "before")
+    @Mapping(source = "afterValue", target = "after")
+    ChangeLogDiffDto toDto(ChangeLogDiff changeLogDiff);
 
     default List<ChangeLogDiff> fromCreate(ChangeLog log, Employee after) {
         return List.of(

--- a/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogDiffRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogDiffRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ChangeLogDiffRepository extends JpaRepository<ChangeLogDiff, Long> {
-        public List<ChangeLogDiff> findAllByChangeLogId(Long changeLogId);
+        List<ChangeLogDiff> findAllByChangeLogId(Long changeLogId);
 }

--- a/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogDiffRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogDiffRepository.java
@@ -1,7 +1,11 @@
 package com.team1.hrbank.domain.changelog.repository;
 
+import com.team1.hrbank.domain.changelog.dto.data.ChangeLogDiffDto;
 import com.team1.hrbank.domain.changelog.entity.ChangeLogDiff;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChangeLogDiffRepository extends JpaRepository<ChangeLogDiff, Long> {
+        public List<ChangeLogDiff> findAllByChangeLogId(Long changeLogId);
 }

--- a/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogRepository.java
@@ -15,8 +15,8 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             FROM change_logs
             WHERE
                 (:employeeNumber IS NULL OR employee_number = :employeeNumber)
-                AND (:memo IS NULL OR memo ILIKE CONCAT('%', :memo, '%'))
-                AND (:ipAddress IS NULL OR ip_address ILIKE CONCAT('%', :ipAddress, '%'))
+                AND (:memo IS NULL OR LOWER(memo) LIKE '%' || LOWER(:memo) || '%')
+                AND (:ipAddress IS NULL OR LOWER(ip_address) LIKE '%' || LOWER(:ipAddress) || '%')
                 AND (:type IS NULL OR type = :type)
                 AND (
                     (:from IS NULL AND :to IS NULL)
@@ -25,17 +25,12 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
                     OR (created_at BETWEEN :from AND :to)
                 )
                 AND (:lastId IS NULL OR
-                     (:direction = 'ASC' AND id > :lastId)
-                     OR (:direction = 'DESC' AND id < :lastId)
+                    (:direction = 'ASC' AND id > :lastId)
+                    OR (:direction = 'DESC' AND id < :lastId)
                 )
-            ORDER BY
-                CASE WHEN :sortKey = 'CREATED_AT_ASC' THEN created_at END ASC,
-                CASE WHEN :sortKey = 'CREATED_AT_DESC' THEN created_at END DESC,
-                CASE WHEN :sortKey = 'IP_ADDRESS_ASC' THEN ip_address END ASC,
-                CASE WHEN :sortKey = 'IP_ADDRESS_DESC' THEN ip_address END DESC
             LIMIT :limit
             """, nativeQuery = true)
-    List<ChangeLog> findAllByCondition(
+    List<ChangeLog> findAllByConditionWithoutSort(
             @Param("employeeNumber") String employeeNumber,
             @Param("memo") String memo,
             @Param("ipAddress") String ipAddress,
@@ -44,7 +39,8 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             @Param("to") LocalDateTime to,
             @Param("lastId") Long lastId,
             @Param("direction") String direction,
-            @Param("sortKey") String sortKey,
             @Param("limit") int limit
     );
+
+    Optional<ChangeLog> findFirstByUpdatedAtDesc();
 }

--- a/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogDiffService.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogDiffService.java
@@ -11,12 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ChangeLogDiffService {
     private final ChangeLogDiffRepository changeLogDiffRepository;
     private final ChangeLogDiffMapper changeLogDiffMapper;
 
+    @Transactional(readOnly = true)
     public List<ChangeLogDiffDto> findAllByChangeLogId(Long changeLogId) {
         List<ChangeLogDiff> changeLogDiffs = changeLogDiffRepository.findAllByChangeLogId(changeLogId);
         return changeLogDiffs.stream()

--- a/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogDiffService.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogDiffService.java
@@ -1,0 +1,26 @@
+package com.team1.hrbank.domain.changelog.service;
+
+import com.team1.hrbank.domain.changelog.dto.data.ChangeLogDiffDto;
+import com.team1.hrbank.domain.changelog.entity.ChangeLogDiff;
+import com.team1.hrbank.domain.changelog.mapper.ChangeLogDiffMapper;
+import com.team1.hrbank.domain.changelog.repository.ChangeLogDiffRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChangeLogDiffService {
+    private final ChangeLogDiffRepository changeLogDiffRepository;
+    private final ChangeLogDiffMapper changeLogDiffMapper;
+
+    public List<ChangeLogDiffDto> findAllByChangeLogId(Long changeLogId) {
+        List<ChangeLogDiff> changeLogDiffs = changeLogDiffRepository.findAllByChangeLogId(changeLogId);
+        return changeLogDiffs.stream()
+                .map(changeLogDiffMapper::toDto)
+                .toList();
+    }
+}

--- a/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogService.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogService.java
@@ -31,7 +31,7 @@ public class ChangeLogService {
 
     @Transactional(readOnly = true)
     public ChangeLogSearchResponse findAll(ChangeLogSearchRequest request) {
-        int limit = DEFAULT_PAGE_SIZE + 1;
+        int limit = DEFAULT_PAGE_SIZE + 1; //다음 페이지 유무 판별을 위해 +1
 
         List<ChangeLog> changeLogs = changeLogRepository.findAllByConditionWithoutSort(
                 request.employeeNumber(),
@@ -43,8 +43,7 @@ public class ChangeLogService {
                 request.lastId(),
                 getDirection(request.sortKey()),
                 limit
-        );
-
+        ); //DB 조회
 
         Comparator<ChangeLog> comparator = getComparator(request.sortKey());
         changeLogs.sort(comparator);
@@ -64,13 +63,13 @@ public class ChangeLogService {
 
     private Comparator<ChangeLog> getComparator(ChangeLogSearchRequest.SortKey sortKey) {
         return switch (sortKey) {
-            case CREATED_AT_ASC -> Comparator.comparing(ChangeLog::getCreatedAt);
-            case CREATED_AT_DESC -> Comparator.comparing(ChangeLog::getCreatedAt).reversed();
-            case IP_ADDRESS_ASC -> Comparator.comparing(
+            case CREATED_AT_ASC -> Comparator.comparing(ChangeLog::getCreatedAt); // 오래된순
+            case CREATED_AT_DESC -> Comparator.comparing(ChangeLog::getCreatedAt).reversed(); // 최신순
+            case IP_ADDRESS_ASC -> Comparator.comparing( // IP 오름차순
                     ChangeLog::getIpAddress,
                     Comparator.nullsLast(String::compareToIgnoreCase)
             );
-            case IP_ADDRESS_DESC -> Comparator.comparing(
+            case IP_ADDRESS_DESC -> Comparator.comparing( // IP 내림차순
                     ChangeLog::getIpAddress,
                     Comparator.nullsLast(String::compareToIgnoreCase)
             ).reversed();

--- a/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogService.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/service/ChangeLogService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -28,9 +29,11 @@ public class ChangeLogService {
 
     private static final int DEFAULT_PAGE_SIZE = 20; //한번에 불러오는 데이터 갯수
 
+    @Transactional(readOnly = true)
     public ChangeLogSearchResponse findAll(ChangeLogSearchRequest request) {
         int limit = DEFAULT_PAGE_SIZE + 1;
-        List<ChangeLog> changeLogs = changeLogRepository.findAllByCondition(
+
+        List<ChangeLog> changeLogs = changeLogRepository.findAllByConditionWithoutSort(
                 request.employeeNumber(),
                 request.memo(),
                 request.ipAddress(),
@@ -39,9 +42,12 @@ public class ChangeLogService {
                 request.to(),
                 request.lastId(),
                 getDirection(request.sortKey()),
-                request.sortKey().name(),
                 limit
         );
+
+
+        Comparator<ChangeLog> comparator = getComparator(request.sortKey());
+        changeLogs.sort(comparator);
 
         boolean hasNext = changeLogs.size() > DEFAULT_PAGE_SIZE;
         Long nextCursor = hasNext ? changeLogs.get(DEFAULT_PAGE_SIZE).getId() : null;
@@ -56,8 +62,23 @@ public class ChangeLogService {
         );
     }
 
-    private String getDirection(ChangeLogSearchRequest.SortKey key) {
-        return switch (key) {
+    private Comparator<ChangeLog> getComparator(ChangeLogSearchRequest.SortKey sortKey) {
+        return switch (sortKey) {
+            case CREATED_AT_ASC -> Comparator.comparing(ChangeLog::getCreatedAt);
+            case CREATED_AT_DESC -> Comparator.comparing(ChangeLog::getCreatedAt).reversed();
+            case IP_ADDRESS_ASC -> Comparator.comparing(
+                    ChangeLog::getIpAddress,
+                    Comparator.nullsLast(String::compareToIgnoreCase)
+            );
+            case IP_ADDRESS_DESC -> Comparator.comparing(
+                    ChangeLog::getIpAddress,
+                    Comparator.nullsLast(String::compareToIgnoreCase)
+            ).reversed();
+        };
+    }
+
+    private String getDirection(ChangeLogSearchRequest.SortKey sortKey) {
+        return switch (sortKey) {
             case CREATED_AT_ASC, IP_ADDRESS_ASC -> "ASC";
             case CREATED_AT_DESC, IP_ADDRESS_DESC -> "DESC";
         };


### PR DESCRIPTION
## 관련 이슈

- close #32

## 주요 변경 사항

- 이력 상세 조회 기능 구현
- ChangeLogRepository에서 ANSI 표준 sql만 사용하도록 리팩토링