### PR TITLE
feat: 기간 별 직원수 추이 조회 (#20)

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/controller/EmployeeController.java
@@ -6,7 +6,9 @@ import com.team1.hrbank.domain.employee.dto.request.CursorPageRequestDto;
 import com.team1.hrbank.domain.employee.dto.request.EmployeeCreateRequestDto;
 import com.team1.hrbank.domain.employee.dto.request.EmployeeUpdateRequestDto;
 import com.team1.hrbank.domain.employee.dto.response.CursorPageResponseEmployeeDto;
+import com.team1.hrbank.domain.employee.dto.response.EmployeeTrendDto;
 import com.team1.hrbank.domain.employee.entity.EmployeeStatus;
+import com.team1.hrbank.domain.employee.entity.TimeUnitType;
 import com.team1.hrbank.domain.employee.service.EmployeeService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,62 +39,76 @@ public class EmployeeController {
 
   private final EmployeeService employeeService;
 
-  @PostMapping
-  public ResponseEntity<EmployeeDto> createEmployee(
-      @RequestPart("employee") EmployeeCreateRequestDto employeeCreateRequestDto,
-      @RequestPart(value = "profile", required = false) MultipartFile profile,
-      HttpServletRequest request) {
-
-    String clientIp = request.getRemoteAddr();
-    EmployeeDto employeeDto = employeeService.createEmployee(employeeCreateRequestDto, profile,
-        clientIp);
-    return ResponseEntity.status(HttpStatus.CREATED).body(employeeDto);
-  }
-
-  @PatchMapping("/{id}")
-  public ResponseEntity<EmployeeDto> updateEmployee(@PathVariable Long id,
-      @RequestPart("employee") EmployeeUpdateRequestDto employeeUpdateRequestDto,
-      @RequestPart(value = "profile", required = false) MultipartFile profile,
-      HttpServletRequest request) {
-
-    String clientIp = request.getRemoteAddr();
-    EmployeeDto employeeDto = employeeService.updateEmployee(id, employeeUpdateRequestDto, profile,
-        clientIp);
-    return ResponseEntity.ok(employeeDto);
-  }
-
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteEmployee(@PathVariable Long id, HttpServletRequest request) {
-    String clientIp = request.getRemoteAddr();
-    employeeService.deleteEmployee(id, clientIp);
-    return ResponseEntity.noContent().build();
-  }
-
-  @GetMapping
-  public ResponseEntity<CursorPageResponseEmployeeDto> findEmployees(
-      @RequestParam(required = false) CursorPageRequestDto cursorPageRequestDto) {
-    CursorPageResponseEmployeeDto cursorPageResponseEmployeeDto = employeeService.findEmployees(
-        cursorPageRequestDto);
-    return ResponseEntity.ok(cursorPageResponseEmployeeDto);
-  }
-
-  @GetMapping("/{id}")
-  public ResponseEntity<EmployeeDto> findEmployee(@PathVariable("id") Long id) {
-    EmployeeDto employeeDto = employeeService.findEmployee(id);
-    return ResponseEntity.ok(employeeDto);
-  }
+//  @PostMapping
+//  public ResponseEntity<EmployeeDto> createEmployee(
+//      @RequestPart("employee") EmployeeCreateRequestDto employeeCreateRequestDto,
+//      @RequestPart(value = "profile", required = false) MultipartFile profile,
+//      HttpServletRequest request) {
+//
+//    String clientIp = request.getRemoteAddr();
+//    EmployeeDto employeeDto = employeeService.createEmployee(employeeCreateRequestDto, profile,
+//        clientIp);
+//    return ResponseEntity.status(HttpStatus.CREATED).body(employeeDto);
+//  }
+//
+//  @PatchMapping("/{id}")
+//  public ResponseEntity<EmployeeDto> updateEmployee(@PathVariable Long id,
+//      @RequestPart("employee") EmployeeUpdateRequestDto employeeUpdateRequestDto,
+//      @RequestPart(value = "profile", required = false) MultipartFile profile,
+//      HttpServletRequest request) {
+//
+//    String clientIp = request.getRemoteAddr();
+//    EmployeeDto employeeDto = employeeService.updateEmployee(id, employeeUpdateRequestDto, profile,
+//        clientIp);
+//    return ResponseEntity.ok(employeeDto);
+//  }
+//
+//  @DeleteMapping("/{id}")
+//  public ResponseEntity<Void> deleteEmployee(@PathVariable Long id, HttpServletRequest request) {
+//    String clientIp = request.getRemoteAddr();
+//    employeeService.deleteEmployee(id, clientIp);
+//    return ResponseEntity.noContent().build();
+//  }
+//
+//  @GetMapping
+//  public ResponseEntity<CursorPageResponseEmployeeDto> findEmployees(
+//      @RequestParam(required = false) CursorPageRequestDto cursorPageRequestDto) {
+//    CursorPageResponseEmployeeDto cursorPageResponseEmployeeDto = employeeService.findEmployees(
+//        cursorPageRequestDto);
+//    return ResponseEntity.ok(cursorPageResponseEmployeeDto);
+//  }
+//
+//  @GetMapping("/{id}")
+//  public ResponseEntity<EmployeeDto> findEmployee(@PathVariable("id") Long id) {
+//    EmployeeDto employeeDto = employeeService.findEmployee(id);
+//    return ResponseEntity.ok(employeeDto);
+//  }
 
   // 대시보드
   @GetMapping("/count")
   public ResponseEntity<Long> countEmployees(
       @RequestParam(required = false) EmployeeStatus status,
-      @RequestParam(required = false) @DateTimeFormat(iso= ISO.DATE) LocalDate fromDate,
-      @RequestParam(required = false) @DateTimeFormat(iso= ISO.DATE) LocalDate toDate) {
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate fromDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate toDate) {
 
     long employeesCount = employeeService.countEmployees(status, fromDate, toDate);
 
     return ResponseEntity
         .status(HttpStatus.OK)
         .body(employeesCount);
+  }
+
+  @GetMapping("/status/trend")
+  public ResponseEntity<List<EmployeeTrendDto>> statusTrendEmployees(
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate to,
+      @RequestParam(required = false, defaultValue = "month") String unit) {
+
+    TimeUnitType timeUnitType = TimeUnitType.fromString(unit);
+    List<EmployeeTrendDto> trend = employeeService.getEmployeeTrend(from, to, timeUnitType);
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(trend);
   }
 }

--- a/src/main/java/com/team1/hrbank/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/controller/EmployeeController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -39,50 +38,50 @@ public class EmployeeController {
 
   private final EmployeeService employeeService;
 
-//  @PostMapping
-//  public ResponseEntity<EmployeeDto> createEmployee(
-//      @RequestPart("employee") EmployeeCreateRequestDto employeeCreateRequestDto,
-//      @RequestPart(value = "profile", required = false) MultipartFile profile,
-//      HttpServletRequest request) {
-//
-//    String clientIp = request.getRemoteAddr();
-//    EmployeeDto employeeDto = employeeService.createEmployee(employeeCreateRequestDto, profile,
-//        clientIp);
-//    return ResponseEntity.status(HttpStatus.CREATED).body(employeeDto);
-//  }
-//
-//  @PatchMapping("/{id}")
-//  public ResponseEntity<EmployeeDto> updateEmployee(@PathVariable Long id,
-//      @RequestPart("employee") EmployeeUpdateRequestDto employeeUpdateRequestDto,
-//      @RequestPart(value = "profile", required = false) MultipartFile profile,
-//      HttpServletRequest request) {
-//
-//    String clientIp = request.getRemoteAddr();
-//    EmployeeDto employeeDto = employeeService.updateEmployee(id, employeeUpdateRequestDto, profile,
-//        clientIp);
-//    return ResponseEntity.ok(employeeDto);
-//  }
-//
-//  @DeleteMapping("/{id}")
-//  public ResponseEntity<Void> deleteEmployee(@PathVariable Long id, HttpServletRequest request) {
-//    String clientIp = request.getRemoteAddr();
-//    employeeService.deleteEmployee(id, clientIp);
-//    return ResponseEntity.noContent().build();
-//  }
-//
-//  @GetMapping
-//  public ResponseEntity<CursorPageResponseEmployeeDto> findEmployees(
-//      @RequestParam(required = false) CursorPageRequestDto cursorPageRequestDto) {
-//    CursorPageResponseEmployeeDto cursorPageResponseEmployeeDto = employeeService.findEmployees(
-//        cursorPageRequestDto);
-//    return ResponseEntity.ok(cursorPageResponseEmployeeDto);
-//  }
-//
-//  @GetMapping("/{id}")
-//  public ResponseEntity<EmployeeDto> findEmployee(@PathVariable("id") Long id) {
-//    EmployeeDto employeeDto = employeeService.findEmployee(id);
-//    return ResponseEntity.ok(employeeDto);
-//  }
+  @PostMapping
+  public ResponseEntity<EmployeeDto> createEmployee(
+      @RequestPart("employee") EmployeeCreateRequestDto employeeCreateRequestDto,
+      @RequestPart(value = "profile", required = false) MultipartFile profile,
+      HttpServletRequest request) {
+
+    String clientIp = request.getRemoteAddr();
+    EmployeeDto employeeDto = employeeService.createEmployee(employeeCreateRequestDto, profile,
+        clientIp);
+    return ResponseEntity.status(HttpStatus.CREATED).body(employeeDto);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<EmployeeDto> updateEmployee(@PathVariable Long id,
+      @RequestPart("employee") EmployeeUpdateRequestDto employeeUpdateRequestDto,
+      @RequestPart(value = "profile", required = false) MultipartFile profile,
+      HttpServletRequest request) {
+
+    String clientIp = request.getRemoteAddr();
+    EmployeeDto employeeDto = employeeService.updateEmployee(id, employeeUpdateRequestDto, profile,
+        clientIp);
+    return ResponseEntity.ok(employeeDto);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteEmployee(@PathVariable Long id, HttpServletRequest request) {
+    String clientIp = request.getRemoteAddr();
+    employeeService.deleteEmployee(id, clientIp);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseEmployeeDto> findEmployees(
+      @RequestParam(required = false) CursorPageRequestDto cursorPageRequestDto) {
+    CursorPageResponseEmployeeDto cursorPageResponseEmployeeDto = employeeService.findEmployees(
+        cursorPageRequestDto);
+    return ResponseEntity.ok(cursorPageResponseEmployeeDto);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<EmployeeDto> findEmployee(@PathVariable("id") Long id) {
+    EmployeeDto employeeDto = employeeService.findEmployee(id);
+    return ResponseEntity.ok(employeeDto);
+  }
 
   // 대시보드
   @GetMapping("/count")

--- a/src/main/java/com/team1/hrbank/domain/employee/dto/response/EmployeeTrendDto.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/dto/response/EmployeeTrendDto.java
@@ -1,0 +1,12 @@
+package com.team1.hrbank.domain.employee.dto.response;
+
+import java.time.LocalDate;
+
+public record EmployeeTrendDto(
+    LocalDate date,
+    long count,
+    long change,
+    double changeRate
+) {
+
+}

--- a/src/main/java/com/team1/hrbank/domain/employee/entity/TimeUnitType.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/entity/TimeUnitType.java
@@ -1,0 +1,17 @@
+package com.team1.hrbank.domain.employee.entity;
+
+public enum TimeUnitType {
+  DAY,
+  WEEK,
+  MONTH,
+  QUARTER,
+  YEAR;
+
+  public static TimeUnitType fromString(String value) {
+    try {
+      return valueOf(value.toUpperCase());
+    } catch (Exception e) {
+      return MONTH;
+    }
+  }
+}

--- a/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
@@ -3,7 +3,6 @@ package com.team1.hrbank.domain.employee.repository;
 import com.team1.hrbank.domain.employee.entity.Employee;
 import com.team1.hrbank.domain.employee.entity.EmployeeStatus;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,16 +11,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long>,
     EmployeeRepositoryCustom {
-//
-//  Optional<Employee> findByEmployeeNumber(String employeeNumber);
-//
-//  Optional<Employee> findByEmail(String email);
-//
-//  long countByDepartmentId(Long departmentId);
-//
-//  // JOIN FETCH 대체용
-//  @EntityGraph(attributePaths = {"department", "fileMetaData"})
-//  Optional<Employee> findById(Long id);
+
+  Optional<Employee> findByEmployeeNumber(String employeeNumber);
+
+  Optional<Employee> findByEmail(String email);
+
+  long countByDepartmentId(Long departmentId);
+
+  // JOIN FETCH 대체용
+  @EntityGraph(attributePaths = {"department", "fileMetaData"})
+  Optional<Employee> findById(Long id);
 
   // 대시보드
   @Query("""

--- a/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
@@ -12,16 +12,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long>,
     EmployeeRepositoryCustom {
-
-  Optional<Employee> findByEmployeeNumber(String employeeNumber);
-
-  Optional<Employee> findByEmail(String email);
-
-  long countByDepartmentId(Long departmentId);
-
-  // JOIN FETCH 대체용
-  @EntityGraph(attributePaths = {"department", "fileMetaData"})
-  Optional<Employee> findById(Long id);
+//
+//  Optional<Employee> findByEmployeeNumber(String employeeNumber);
+//
+//  Optional<Employee> findByEmail(String email);
+//
+//  long countByDepartmentId(Long departmentId);
+//
+//  // JOIN FETCH 대체용
+//  @EntityGraph(attributePaths = {"department", "fileMetaData"})
+//  Optional<Employee> findById(Long id);
 
   // 대시보드
   @Query("""
@@ -34,7 +34,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
       SELECT COUNT(e) FROM Employee e
           WHERE e.hireDate BETWEEN :fromDate AND :toDate
       """)
-  int countByHireDate(
+  long countByHireDate(
       @Param("fromDate") LocalDate fromDate,
       @Param("toDate") LocalDate toDate
   );
@@ -42,5 +42,5 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
   @Query("""
       SELECT COUNT(e) FROM Employee e
       """)
-  int countAll ();
+  long countAll ();
 }

--- a/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
@@ -1,14 +1,17 @@
 package com.team1.hrbank.domain.employee.service;
 
-import com.team1.hrbank.domain.changelog.service.ChangeLogService;
-import com.team1.hrbank.domain.department.entity.Department;
-import com.team1.hrbank.domain.department.repository.DepartmentRepository;
+//import com.team1.hrbank.domain.changelog.service.ChangeLogService;
+//import com.team1.hrbank.domain.department.entity.Department;
+//import com.team1.hrbank.domain.department.repository.DepartmentRepository;
+
 import com.team1.hrbank.domain.employee.dto.EmployeeDto;
 import com.team1.hrbank.domain.employee.dto.request.CursorPageRequestDto;
 import com.team1.hrbank.domain.employee.dto.request.EmployeeUpdateRequestDto;
 import com.team1.hrbank.domain.employee.dto.response.CursorPageResponseEmployeeDto;
+import com.team1.hrbank.domain.employee.dto.response.EmployeeTrendDto;
 import com.team1.hrbank.domain.employee.entity.Employee;
 import com.team1.hrbank.domain.employee.entity.EmployeeStatus;
+import com.team1.hrbank.domain.employee.entity.TimeUnitType;
 import com.team1.hrbank.domain.employee.mapper.EmployeeMapper;
 import com.team1.hrbank.domain.employee.repository.EmployeeRepository;
 import com.team1.hrbank.domain.employee.dto.request.EmployeeCreateRequestDto;
@@ -16,6 +19,8 @@ import com.team1.hrbank.domain.file.service.FileMetadataService;
 import com.team1.hrbank.domain.file.entity.FileMetadata;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -29,160 +34,160 @@ import org.springframework.web.multipart.MultipartFile;
 public class EmployeeService {
 
   private final EmployeeRepository employeeRepository;
-  private final DepartmentRepository departmentRepository;
+  //  private final DepartmentRepository departmentRepository;
   private final FileMetadataService fileMetadataService;
   private final EmployeeMapper employeeMapper;
-  private final ChangeLogService changeLogService;
+//  private final ChangeLogService changeLogService;
 
-  @Transactional
-  public EmployeeDto createEmployee(EmployeeCreateRequestDto employeeCreateRequestDto,
-      MultipartFile profile, String clientIp) {
-
-    validateDuplicateEmail(employeeCreateRequestDto.email());
-    Department department = getValidateDepartment(employeeCreateRequestDto.departmentId());
-
-    String employeeNumber = createEmployeeNumber();
-    Employee employee = employeeMapper.toEmployee(employeeCreateRequestDto, employeeNumber,
-        EmployeeStatus.ACTIVE, department);
-
-    Employee savedEmployee = employeeRepository.save(employee);
-
-    if (profile != null && !profile.isEmpty()) {
-      FileMetadata fileMetadata = fileMetadataService.uploadProfileImage(savedEmployee.getId(),
-          profile);
-      savedEmployee.setFileMetadata(fileMetadata);
-    }
-
-    changeLogService.recordCreateLog(savedEmployee, employeeCreateRequestDto.memo(), clientIp);
-
-    return employeeMapper.toEmployeeDto(savedEmployee);
-  }
-
-  @Transactional
-  public EmployeeDto updateEmployee(Long employeeId,
-      EmployeeUpdateRequestDto employeeUpdateRequestDto,
-      MultipartFile profile,
-      String clientIp) {
-    validateDuplicateEmail(employeeUpdateRequestDto.email());
-    Department newDepartment = getValidateDepartment(employeeUpdateRequestDto.departmentId());
-    Employee findEmployee = getValidateEmployee(employeeId);
-    FileMetadata fileMetadata = findEmployee.getFileMetadata();
-    Department department = findEmployee.getDepartment();
-
-    Department oldDepartment = new Department(department.getName(),
-        department.getDescription(),
-        department.getEstablishedDate(), department.getEmployees());
-
-    FileMetadata oldFileMetadata = new FileMetadata(fileMetadata.getOriginalName(),
-        fileMetadata.getSavedName(), fileMetadata.getFilePath(), fileMetadata.getFileType(),
-        fileMetadata.getFileSize(), fileMetadata.getFilePath());
-
-    Employee oldEmployee = new Employee(
-        findEmployee.getEmployeeNumber(), findEmployee.getName(), findEmployee.getEmail(),
-        findEmployee.getPosition(), findEmployee.getHireDate(), findEmployee.getStatus(),
-        oldDepartment, oldFileMetadata);
-
-    findEmployee.setName(employeeUpdateRequestDto.name());
-    findEmployee.setEmail(employeeUpdateRequestDto.email());
-    findEmployee.setPosition(employeeUpdateRequestDto.position());
-    findEmployee.setHireDate(employeeUpdateRequestDto.hireDate());
-    findEmployee.setStatus(EmployeeStatus.valueOf(employeeUpdateRequestDto.status()));
-
-    FileMetadata newFileMetadata = fileMetadataService.uploadProfileImage(findEmployee.getId(),
-        profile);
-
-    findEmployee.setDepartment(newDepartment);
-    findEmployee.setFileMetadata(newFileMetadata);
-
-    changeLogService.recordUpdateLog(oldEmployee, findEmployee, employeeUpdateRequestDto.memo(),
-        clientIp);
-
-    return employeeMapper.toEmployeeDto(employeeRepository.save(findEmployee));
-  }
-
-  @Transactional
-  public void deleteEmployee(Long employeeId, String clientIp) {
-    Employee employee = getValidateEmployee(employeeId);
-    changeLogService.recordDeleteLog(employee, "직원 삭제", clientIp);
-    // 프로토 타입에서 확인 결과 직원 삭제는 따로 메모는 없고 일괄적으로 "직원 삭제" 란 메시지가 자동으로 들어갑니다.
-    employeeRepository.delete(employee);
-  }
-
-  public CursorPageResponseEmployeeDto findEmployees(CursorPageRequestDto cursorPageRequestDto) {
-
-    List<Employee> employees = employeeRepository.findAllEmployeesByRequestNative(
-        cursorPageRequestDto);
-    Long totalElements = (long) employees.size();
-
-    int startIndex = 0;  // 다음 커서를 찾으면
-    Long idAfter = cursorPageRequestDto.idAfter(); // 이게 Long 타입이라고 가정
-
-    if (idAfter != null) {
-      for (int i = 0; i < employees.size(); i++) {
-        if (employees.get(i).getId().equals(idAfter)) {
-          startIndex = i;
-          break;
-        }
-      }
-    }
-
-    int endIndex = (employees.size() - startIndex) % cursorPageRequestDto.size() == 0
-        ? cursorPageRequestDto.size() + startIndex
-        : (employees.size() - startIndex) % cursorPageRequestDto.size() + startIndex;
-
-    List<Employee> pagedEmployees = employees.subList(startIndex, endIndex);
-    List<EmployeeDto> content = pagedEmployees.stream()
-        .map(employeeMapper::toEmployeeDto)
-        .toList();
-
-    String nextCursor = null;
-    Long nextIdAfter = null;
-    Integer size = endIndex - startIndex;
-    Boolean hasNext = null;
-
-    if (endIndex + 1 < totalElements) {
-
-      switch (cursorPageRequestDto.sortField()) {
-        case "name":
-          nextCursor = employees.get(endIndex + 1).getName();
-          break;
-        case "employeeNumber":
-          nextCursor = employees.get(endIndex + 1).getEmployeeNumber();
-          break;
-        case "hireDate":
-          nextCursor = String.valueOf(employees.get(endIndex + 1).getHireDate());
-          break;
-      }
-
-      nextIdAfter = employees.get(endIndex + 1).getId();
-      hasNext = true;
-    }
-
-    return new CursorPageResponseEmployeeDto(content, nextCursor, nextIdAfter, size, totalElements,
-        hasNext);
-  }
-
-  public EmployeeDto findEmployee(Long employeeId) {
-    return employeeMapper.toEmployeeDto(employeeRepository.findById(employeeId).get());
-  }
-
-  private String createEmployeeNumber() {
-    String prefix = "EMP"; // Employee 의 약자
-    String year = String.valueOf(LocalDate.now().getYear()); // 연도
-
-    String timestamp = String.valueOf(System.currentTimeMillis());  // 13자리
-    int randomTwoDigits = (int) (Math.random() * 90) + 10;         // 10~99 사이 두자리 난수
-    String unique = randomTwoDigits + timestamp; // 랜덤한 15자리 숫자
-
-    String employeeNumber = prefix + "-" + year + "-" + unique;
-
-    // 중복 확인 후 재귀 호출
-    if (employeeRepository.findByEmployeeNumber(employeeNumber).isPresent()) {
-      return createEmployeeNumber(); // 중복 시 다시 생성
-    }
-
-    return employeeNumber;
-  }
+//  @Transactional
+//  public EmployeeDto createEmployee(EmployeeCreateRequestDto employeeCreateRequestDto,
+//      MultipartFile profile, String clientIp) {
+//
+//    validateDuplicateEmail(employeeCreateRequestDto.email());
+//    Department department = getValidateDepartment(employeeCreateRequestDto.departmentId());
+//
+//    String employeeNumber = createEmployeeNumber();
+//    Employee employee = employeeMapper.toEmployee(employeeCreateRequestDto, employeeNumber,
+//        EmployeeStatus.ACTIVE, department);
+//
+//    Employee savedEmployee = employeeRepository.save(employee);
+//
+//    if (profile != null && !profile.isEmpty()) {
+//      FileMetadata fileMetadata = fileMetadataService.uploadProfileImage(savedEmployee.getId(),
+//          profile);
+//      savedEmployee.setFileMetadata(fileMetadata);
+//    }
+//
+//    changeLogService.recordCreateLog(savedEmployee, employeeCreateRequestDto.memo(), clientIp);
+//
+//    return employeeMapper.toEmployeeDto(savedEmployee);
+//  }
+//
+//  @Transactional
+//  public EmployeeDto updateEmployee(Long employeeId,
+//      EmployeeUpdateRequestDto employeeUpdateRequestDto,
+//      MultipartFile profile,
+//      String clientIp) {
+//    validateDuplicateEmail(employeeUpdateRequestDto.email());
+//    Department newDepartment = getValidateDepartment(employeeUpdateRequestDto.departmentId());
+//    Employee findEmployee = getValidateEmployee(employeeId);
+//    FileMetadata fileMetadata = findEmployee.getFileMetadata();
+//    Department department = findEmployee.getDepartment();
+//
+//    Department oldDepartment = new Department(department.getName(),
+//        department.getDescription(),
+//        department.getEstablishedDate(), department.getEmployees());
+//
+//    FileMetadata oldFileMetadata = new FileMetadata(fileMetadata.getOriginalName(),
+//        fileMetadata.getSavedName(), fileMetadata.getFilePath(), fileMetadata.getFileType(),
+//        fileMetadata.getFileSize(), fileMetadata.getFilePath());
+//
+//    Employee oldEmployee = new Employee(
+//        findEmployee.getEmployeeNumber(), findEmployee.getName(), findEmployee.getEmail(),
+//        findEmployee.getPosition(), findEmployee.getHireDate(), findEmployee.getStatus(),
+//        oldDepartment, oldFileMetadata);
+//
+//    findEmployee.setName(employeeUpdateRequestDto.name());
+//    findEmployee.setEmail(employeeUpdateRequestDto.email());
+//    findEmployee.setPosition(employeeUpdateRequestDto.position());
+//    findEmployee.setHireDate(employeeUpdateRequestDto.hireDate());
+//    findEmployee.setStatus(EmployeeStatus.valueOf(employeeUpdateRequestDto.status()));
+//
+//    FileMetadata newFileMetadata = fileMetadataService.uploadProfileImage(findEmployee.getId(),
+//        profile);
+//
+//    findEmployee.setDepartment(newDepartment);
+//    findEmployee.setFileMetadata(newFileMetadata);
+//
+//    changeLogService.recordUpdateLog(oldEmployee, findEmployee, employeeUpdateRequestDto.memo(),
+//        clientIp);
+//
+//    return employeeMapper.toEmployeeDto(employeeRepository.save(findEmployee));
+//  }
+//
+//  @Transactional
+//  public void deleteEmployee(Long employeeId, String clientIp) {
+//    Employee employee = getValidateEmployee(employeeId);
+//    changeLogService.recordDeleteLog(employee, "직원 삭제", clientIp);
+//    // 프로토 타입에서 확인 결과 직원 삭제는 따로 메모는 없고 일괄적으로 "직원 삭제" 란 메시지가 자동으로 들어갑니다.
+//    employeeRepository.delete(employee);
+//  }
+//
+//  public CursorPageResponseEmployeeDto findEmployees(CursorPageRequestDto cursorPageRequestDto) {
+//
+//    List<Employee> employees = employeeRepository.findAllEmployeesByRequestNative(
+//        cursorPageRequestDto);
+//    Long totalElements = (long) employees.size();
+//
+//    int startIndex = 0;  // 다음 커서를 찾으면
+//    Long idAfter = cursorPageRequestDto.idAfter(); // 이게 Long 타입이라고 가정
+//
+//    if (idAfter != null) {
+//      for (int i = 0; i < employees.size(); i++) {
+//        if (employees.get(i).getId().equals(idAfter)) {
+//          startIndex = i;
+//          break;
+//        }
+//      }
+//    }
+//
+//    int endIndex = (employees.size() - startIndex) % cursorPageRequestDto.size() == 0
+//        ? cursorPageRequestDto.size() + startIndex
+//        : (employees.size() - startIndex) % cursorPageRequestDto.size() + startIndex;
+//
+//    List<Employee> pagedEmployees = employees.subList(startIndex, endIndex);
+//    List<EmployeeDto> content = pagedEmployees.stream()
+//        .map(employeeMapper::toEmployeeDto)
+//        .toList();
+//
+//    String nextCursor = null;
+//    Long nextIdAfter = null;
+//    Integer size = endIndex - startIndex;
+//    Boolean hasNext = null;
+//
+//    if (endIndex + 1 < totalElements) {
+//
+//      switch (cursorPageRequestDto.sortField()) {
+//        case "name":
+//          nextCursor = employees.get(endIndex + 1).getName();
+//          break;
+//        case "employeeNumber":
+//          nextCursor = employees.get(endIndex + 1).getEmployeeNumber();
+//          break;
+//        case "hireDate":
+//          nextCursor = String.valueOf(employees.get(endIndex + 1).getHireDate());
+//          break;
+//      }
+//
+//      nextIdAfter = employees.get(endIndex + 1).getId();
+//      hasNext = true;
+//    }
+//
+//    return new CursorPageResponseEmployeeDto(content, nextCursor, nextIdAfter, size, totalElements,
+//        hasNext);
+//  }
+//
+//  public EmployeeDto findEmployee(Long employeeId) {
+//    return employeeMapper.toEmployeeDto(employeeRepository.findById(employeeId).get());
+//  }
+//
+//  private String createEmployeeNumber() {
+//    String prefix = "EMP"; // Employee 의 약자
+//    String year = String.valueOf(LocalDate.now().getYear()); // 연도
+//
+//    String timestamp = String.valueOf(System.currentTimeMillis());  // 13자리
+//    int randomTwoDigits = (int) (Math.random() * 90) + 10;         // 10~99 사이 두자리 난수
+//    String unique = randomTwoDigits + timestamp; // 랜덤한 15자리 숫자
+//
+//    String employeeNumber = prefix + "-" + year + "-" + unique;
+//
+//    // 중복 확인 후 재귀 호출
+//    if (employeeRepository.findByEmployeeNumber(employeeNumber).isPresent()) {
+//      return createEmployeeNumber(); // 중복 시 다시 생성
+//    }
+//
+//    return employeeNumber;
+//  }
 
   // 대시보드
   public long countEmployees(EmployeeStatus status, LocalDate fromDate, LocalDate toDate) {
@@ -201,21 +206,95 @@ public class EmployeeService {
     return employeeRepository.countAll();
   }
 
-  // 공통 메서드
-  private Department getValidateDepartment(Long departmentId) {
-    return departmentRepository.findById(departmentId)
-        .orElseThrow(() -> new IllegalArgumentException("Department not found"));
-  }
-
-  private void validateDuplicateEmail(String email) {
-    if (employeeRepository.findByEmail(email).isPresent()) {
-      throw new IllegalArgumentException("Email already in use");
+  public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, TimeUnitType unit) {
+    if (to == null) {
+      to = LocalDate.now();
     }
+
+    if (from == null) {
+      from = getDefaultFrom(to, unit, 12);
+    }
+
+    List<EmployeeTrendDto> result = new ArrayList<>();
+    List<LocalDate> periods = calculatePeriods(from, to, unit);
+
+    Long prevCount = null;
+
+    for (int i = 0; i < periods.size() - 1; i++) {
+      LocalDate start = periods.get(i);
+      LocalDate end = periods.get(i + 1).minusDays(1);
+
+      long count = employeeRepository.countByHireDate(start, end);
+      long change = prevCount == null ? 0 : count - prevCount;
+      double changeRate =
+          prevCount == null || prevCount == 0 ? 0.0 : change / (double) prevCount * 100.0;
+
+      result.add(new EmployeeTrendDto(start, count, change, Math.round(changeRate * 10.0) / 10.0));
+      prevCount = count;
+    }
+
+    return result;
   }
 
-  private Employee getValidateEmployee(long employeeId) {
-    return employeeRepository.findById(employeeId)
-        .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+  // 공통 메서드
+//  private Department getValidateDepartment(Long departmentId) {
+//    return departmentRepository.findById(departmentId)
+//        .orElseThrow(() -> new IllegalArgumentException("Department not found"));
+//  }
+//
+//  private void validateDuplicateEmail(String email) {
+//    if (employeeRepository.findByEmail(email).isPresent()) {
+//      throw new IllegalArgumentException("Email already in use");
+//    }
+//  }
+//
+//  private Employee getValidateEmployee(long employeeId) {
+//    return employeeRepository.findById(employeeId)
+//        .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+//  }
+
+  // 대시보드 공통 메서드
+  private LocalDate getDefaultFrom(LocalDate base, TimeUnitType unit, int amount) {
+    return switch (unit) {
+      case DAY -> base.minusDays(amount);
+      case WEEK -> base.minusWeeks(amount);
+      case MONTH -> base.minusMonths(amount);
+      case QUARTER -> base.minusMonths(amount * 3);
+      case YEAR -> base.minusYears(amount);
+    };
+  }
+
+  private List<LocalDate> calculatePeriods(LocalDate from, LocalDate to, TimeUnitType unit) {
+    List<LocalDate> points = new ArrayList<>();
+    LocalDate cursor = truncateToUnit(from, unit);
+    LocalDate limit = to.plusDays(1); // 포함되도록
+
+    while (cursor.isBefore(limit)) {
+      points.add(cursor);
+      cursor = incrementByUnit(cursor, unit);
+    }
+
+    return points;
+  }
+
+  private LocalDate truncateToUnit(LocalDate date, TimeUnitType unit) {
+    return switch (unit) {
+      case DAY -> date;
+      case WEEK -> date.with(ChronoField.DAY_OF_WEEK, 1); // 월요일
+      case MONTH -> date.withDayOfMonth(1);
+      case QUARTER -> date.withMonth(((date.getMonthValue() - 1) / 3) * 3 + 1).withDayOfMonth(1);
+      case YEAR -> date.withDayOfYear(1);
+    };
+  }
+
+  private LocalDate incrementByUnit(LocalDate date, TimeUnitType unit) {
+    return switch (unit) {
+      case DAY -> date.plusDays(1);
+      case WEEK -> date.plusWeeks(1);
+      case MONTH -> date.plusMonths(1);
+      case QUARTER -> date.plusMonths(3);
+      case YEAR -> date.plusYears(1);
+    };
   }
 
 }

--- a/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
@@ -1,8 +1,8 @@
 package com.team1.hrbank.domain.employee.service;
 
-//import com.team1.hrbank.domain.changelog.service.ChangeLogService;
-//import com.team1.hrbank.domain.department.entity.Department;
-//import com.team1.hrbank.domain.department.repository.DepartmentRepository;
+import com.team1.hrbank.domain.changelog.service.ChangeLogService;
+import com.team1.hrbank.domain.department.entity.Department;
+import com.team1.hrbank.domain.department.repository.DepartmentRepository;
 
 import com.team1.hrbank.domain.employee.dto.EmployeeDto;
 import com.team1.hrbank.domain.employee.dto.request.CursorPageRequestDto;
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,160 +33,160 @@ import org.springframework.web.multipart.MultipartFile;
 public class EmployeeService {
 
   private final EmployeeRepository employeeRepository;
-  //  private final DepartmentRepository departmentRepository;
+    private final DepartmentRepository departmentRepository;
   private final FileMetadataService fileMetadataService;
   private final EmployeeMapper employeeMapper;
-//  private final ChangeLogService changeLogService;
+  private final ChangeLogService changeLogService;
 
-//  @Transactional
-//  public EmployeeDto createEmployee(EmployeeCreateRequestDto employeeCreateRequestDto,
-//      MultipartFile profile, String clientIp) {
-//
-//    validateDuplicateEmail(employeeCreateRequestDto.email());
-//    Department department = getValidateDepartment(employeeCreateRequestDto.departmentId());
-//
-//    String employeeNumber = createEmployeeNumber();
-//    Employee employee = employeeMapper.toEmployee(employeeCreateRequestDto, employeeNumber,
-//        EmployeeStatus.ACTIVE, department);
-//
-//    Employee savedEmployee = employeeRepository.save(employee);
-//
-//    if (profile != null && !profile.isEmpty()) {
-//      FileMetadata fileMetadata = fileMetadataService.uploadProfileImage(savedEmployee.getId(),
-//          profile);
-//      savedEmployee.setFileMetadata(fileMetadata);
-//    }
-//
-//    changeLogService.recordCreateLog(savedEmployee, employeeCreateRequestDto.memo(), clientIp);
-//
-//    return employeeMapper.toEmployeeDto(savedEmployee);
-//  }
-//
-//  @Transactional
-//  public EmployeeDto updateEmployee(Long employeeId,
-//      EmployeeUpdateRequestDto employeeUpdateRequestDto,
-//      MultipartFile profile,
-//      String clientIp) {
-//    validateDuplicateEmail(employeeUpdateRequestDto.email());
-//    Department newDepartment = getValidateDepartment(employeeUpdateRequestDto.departmentId());
-//    Employee findEmployee = getValidateEmployee(employeeId);
-//    FileMetadata fileMetadata = findEmployee.getFileMetadata();
-//    Department department = findEmployee.getDepartment();
-//
-//    Department oldDepartment = new Department(department.getName(),
-//        department.getDescription(),
-//        department.getEstablishedDate(), department.getEmployees());
-//
-//    FileMetadata oldFileMetadata = new FileMetadata(fileMetadata.getOriginalName(),
-//        fileMetadata.getSavedName(), fileMetadata.getFilePath(), fileMetadata.getFileType(),
-//        fileMetadata.getFileSize(), fileMetadata.getFilePath());
-//
-//    Employee oldEmployee = new Employee(
-//        findEmployee.getEmployeeNumber(), findEmployee.getName(), findEmployee.getEmail(),
-//        findEmployee.getPosition(), findEmployee.getHireDate(), findEmployee.getStatus(),
-//        oldDepartment, oldFileMetadata);
-//
-//    findEmployee.setName(employeeUpdateRequestDto.name());
-//    findEmployee.setEmail(employeeUpdateRequestDto.email());
-//    findEmployee.setPosition(employeeUpdateRequestDto.position());
-//    findEmployee.setHireDate(employeeUpdateRequestDto.hireDate());
-//    findEmployee.setStatus(EmployeeStatus.valueOf(employeeUpdateRequestDto.status()));
-//
-//    FileMetadata newFileMetadata = fileMetadataService.uploadProfileImage(findEmployee.getId(),
-//        profile);
-//
-//    findEmployee.setDepartment(newDepartment);
-//    findEmployee.setFileMetadata(newFileMetadata);
-//
-//    changeLogService.recordUpdateLog(oldEmployee, findEmployee, employeeUpdateRequestDto.memo(),
-//        clientIp);
-//
-//    return employeeMapper.toEmployeeDto(employeeRepository.save(findEmployee));
-//  }
-//
-//  @Transactional
-//  public void deleteEmployee(Long employeeId, String clientIp) {
-//    Employee employee = getValidateEmployee(employeeId);
-//    changeLogService.recordDeleteLog(employee, "직원 삭제", clientIp);
-//    // 프로토 타입에서 확인 결과 직원 삭제는 따로 메모는 없고 일괄적으로 "직원 삭제" 란 메시지가 자동으로 들어갑니다.
-//    employeeRepository.delete(employee);
-//  }
-//
-//  public CursorPageResponseEmployeeDto findEmployees(CursorPageRequestDto cursorPageRequestDto) {
-//
-//    List<Employee> employees = employeeRepository.findAllEmployeesByRequestNative(
-//        cursorPageRequestDto);
-//    Long totalElements = (long) employees.size();
-//
-//    int startIndex = 0;  // 다음 커서를 찾으면
-//    Long idAfter = cursorPageRequestDto.idAfter(); // 이게 Long 타입이라고 가정
-//
-//    if (idAfter != null) {
-//      for (int i = 0; i < employees.size(); i++) {
-//        if (employees.get(i).getId().equals(idAfter)) {
-//          startIndex = i;
-//          break;
-//        }
-//      }
-//    }
-//
-//    int endIndex = (employees.size() - startIndex) % cursorPageRequestDto.size() == 0
-//        ? cursorPageRequestDto.size() + startIndex
-//        : (employees.size() - startIndex) % cursorPageRequestDto.size() + startIndex;
-//
-//    List<Employee> pagedEmployees = employees.subList(startIndex, endIndex);
-//    List<EmployeeDto> content = pagedEmployees.stream()
-//        .map(employeeMapper::toEmployeeDto)
-//        .toList();
-//
-//    String nextCursor = null;
-//    Long nextIdAfter = null;
-//    Integer size = endIndex - startIndex;
-//    Boolean hasNext = null;
-//
-//    if (endIndex + 1 < totalElements) {
-//
-//      switch (cursorPageRequestDto.sortField()) {
-//        case "name":
-//          nextCursor = employees.get(endIndex + 1).getName();
-//          break;
-//        case "employeeNumber":
-//          nextCursor = employees.get(endIndex + 1).getEmployeeNumber();
-//          break;
-//        case "hireDate":
-//          nextCursor = String.valueOf(employees.get(endIndex + 1).getHireDate());
-//          break;
-//      }
-//
-//      nextIdAfter = employees.get(endIndex + 1).getId();
-//      hasNext = true;
-//    }
-//
-//    return new CursorPageResponseEmployeeDto(content, nextCursor, nextIdAfter, size, totalElements,
-//        hasNext);
-//  }
-//
-//  public EmployeeDto findEmployee(Long employeeId) {
-//    return employeeMapper.toEmployeeDto(employeeRepository.findById(employeeId).get());
-//  }
-//
-//  private String createEmployeeNumber() {
-//    String prefix = "EMP"; // Employee 의 약자
-//    String year = String.valueOf(LocalDate.now().getYear()); // 연도
-//
-//    String timestamp = String.valueOf(System.currentTimeMillis());  // 13자리
-//    int randomTwoDigits = (int) (Math.random() * 90) + 10;         // 10~99 사이 두자리 난수
-//    String unique = randomTwoDigits + timestamp; // 랜덤한 15자리 숫자
-//
-//    String employeeNumber = prefix + "-" + year + "-" + unique;
-//
-//    // 중복 확인 후 재귀 호출
-//    if (employeeRepository.findByEmployeeNumber(employeeNumber).isPresent()) {
-//      return createEmployeeNumber(); // 중복 시 다시 생성
-//    }
-//
-//    return employeeNumber;
-//  }
+  @Transactional
+  public EmployeeDto createEmployee(EmployeeCreateRequestDto employeeCreateRequestDto,
+      MultipartFile profile, String clientIp) {
+
+    validateDuplicateEmail(employeeCreateRequestDto.email());
+    Department department = getValidateDepartment(employeeCreateRequestDto.departmentId());
+
+    String employeeNumber = createEmployeeNumber();
+    Employee employee = employeeMapper.toEmployee(employeeCreateRequestDto, employeeNumber,
+        EmployeeStatus.ACTIVE, department);
+
+    Employee savedEmployee = employeeRepository.save(employee);
+
+    if (profile != null && !profile.isEmpty()) {
+      FileMetadata fileMetadata = fileMetadataService.uploadProfileImage(savedEmployee.getId(),
+          profile);
+      savedEmployee.setFileMetadata(fileMetadata);
+    }
+
+    changeLogService.recordCreateLog(savedEmployee, employeeCreateRequestDto.memo(), clientIp);
+
+    return employeeMapper.toEmployeeDto(savedEmployee);
+  }
+
+  @Transactional
+  public EmployeeDto updateEmployee(Long employeeId,
+      EmployeeUpdateRequestDto employeeUpdateRequestDto,
+      MultipartFile profile,
+      String clientIp) {
+    validateDuplicateEmail(employeeUpdateRequestDto.email());
+    Department newDepartment = getValidateDepartment(employeeUpdateRequestDto.departmentId());
+    Employee findEmployee = getValidateEmployee(employeeId);
+    FileMetadata fileMetadata = findEmployee.getFileMetadata();
+    Department department = findEmployee.getDepartment();
+
+    Department oldDepartment = new Department(department.getName(),
+        department.getDescription(),
+        department.getEstablishedDate(), department.getEmployees());
+
+    FileMetadata oldFileMetadata = new FileMetadata(fileMetadata.getOriginalName(),
+        fileMetadata.getSavedName(), fileMetadata.getFilePath(), fileMetadata.getFileType(),
+        fileMetadata.getFileSize(), fileMetadata.getFilePath());
+
+    Employee oldEmployee = new Employee(
+        findEmployee.getEmployeeNumber(), findEmployee.getName(), findEmployee.getEmail(),
+        findEmployee.getPosition(), findEmployee.getHireDate(), findEmployee.getStatus(),
+        oldDepartment, oldFileMetadata);
+
+    findEmployee.setName(employeeUpdateRequestDto.name());
+    findEmployee.setEmail(employeeUpdateRequestDto.email());
+    findEmployee.setPosition(employeeUpdateRequestDto.position());
+    findEmployee.setHireDate(employeeUpdateRequestDto.hireDate());
+    findEmployee.setStatus(EmployeeStatus.valueOf(employeeUpdateRequestDto.status()));
+
+    FileMetadata newFileMetadata = fileMetadataService.uploadProfileImage(findEmployee.getId(),
+        profile);
+
+    findEmployee.setDepartment(newDepartment);
+    findEmployee.setFileMetadata(newFileMetadata);
+
+    changeLogService.recordUpdateLog(oldEmployee, findEmployee, employeeUpdateRequestDto.memo(),
+        clientIp);
+
+    return employeeMapper.toEmployeeDto(employeeRepository.save(findEmployee));
+  }
+
+  @Transactional
+  public void deleteEmployee(Long employeeId, String clientIp) {
+    Employee employee = getValidateEmployee(employeeId);
+    changeLogService.recordDeleteLog(employee, "직원 삭제", clientIp);
+    // 프로토 타입에서 확인 결과 직원 삭제는 따로 메모는 없고 일괄적으로 "직원 삭제" 란 메시지가 자동으로 들어갑니다.
+    employeeRepository.delete(employee);
+  }
+
+  public CursorPageResponseEmployeeDto findEmployees(CursorPageRequestDto cursorPageRequestDto) {
+
+    List<Employee> employees = employeeRepository.findAllEmployeesByRequestNative(
+        cursorPageRequestDto);
+    Long totalElements = (long) employees.size();
+
+    int startIndex = 0;  // 다음 커서를 찾으면
+    Long idAfter = cursorPageRequestDto.idAfter(); // 이게 Long 타입이라고 가정
+
+    if (idAfter != null) {
+      for (int i = 0; i < employees.size(); i++) {
+        if (employees.get(i).getId().equals(idAfter)) {
+          startIndex = i;
+          break;
+        }
+      }
+    }
+
+    int endIndex = (employees.size() - startIndex) % cursorPageRequestDto.size() == 0
+        ? cursorPageRequestDto.size() + startIndex
+        : (employees.size() - startIndex) % cursorPageRequestDto.size() + startIndex;
+
+    List<Employee> pagedEmployees = employees.subList(startIndex, endIndex);
+    List<EmployeeDto> content = pagedEmployees.stream()
+        .map(employeeMapper::toEmployeeDto)
+        .toList();
+
+    String nextCursor = null;
+    Long nextIdAfter = null;
+    Integer size = endIndex - startIndex;
+    Boolean hasNext = null;
+
+    if (endIndex + 1 < totalElements) {
+
+      switch (cursorPageRequestDto.sortField()) {
+        case "name":
+          nextCursor = employees.get(endIndex + 1).getName();
+          break;
+        case "employeeNumber":
+          nextCursor = employees.get(endIndex + 1).getEmployeeNumber();
+          break;
+        case "hireDate":
+          nextCursor = String.valueOf(employees.get(endIndex + 1).getHireDate());
+          break;
+      }
+
+      nextIdAfter = employees.get(endIndex + 1).getId();
+      hasNext = true;
+    }
+
+    return new CursorPageResponseEmployeeDto(content, nextCursor, nextIdAfter, size, totalElements,
+        hasNext);
+  }
+
+  public EmployeeDto findEmployee(Long employeeId) {
+    return employeeMapper.toEmployeeDto(employeeRepository.findById(employeeId).get());
+  }
+
+  private String createEmployeeNumber() {
+    String prefix = "EMP"; // Employee 의 약자
+    String year = String.valueOf(LocalDate.now().getYear()); // 연도
+
+    String timestamp = String.valueOf(System.currentTimeMillis());  // 13자리
+    int randomTwoDigits = (int) (Math.random() * 90) + 10;         // 10~99 사이 두자리 난수
+    String unique = randomTwoDigits + timestamp; // 랜덤한 15자리 숫자
+
+    String employeeNumber = prefix + "-" + year + "-" + unique;
+
+    // 중복 확인 후 재귀 호출
+    if (employeeRepository.findByEmployeeNumber(employeeNumber).isPresent()) {
+      return createEmployeeNumber(); // 중복 시 다시 생성
+    }
+
+    return employeeNumber;
+  }
 
   // 대시보드
   public long countEmployees(EmployeeStatus status, LocalDate fromDate, LocalDate toDate) {
@@ -237,21 +236,21 @@ public class EmployeeService {
   }
 
   // 공통 메서드
-//  private Department getValidateDepartment(Long departmentId) {
-//    return departmentRepository.findById(departmentId)
-//        .orElseThrow(() -> new IllegalArgumentException("Department not found"));
-//  }
-//
-//  private void validateDuplicateEmail(String email) {
-//    if (employeeRepository.findByEmail(email).isPresent()) {
-//      throw new IllegalArgumentException("Email already in use");
-//    }
-//  }
-//
-//  private Employee getValidateEmployee(long employeeId) {
-//    return employeeRepository.findById(employeeId)
-//        .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
-//  }
+  private Department getValidateDepartment(Long departmentId) {
+    return departmentRepository.findById(departmentId)
+        .orElseThrow(() -> new IllegalArgumentException("Department not found"));
+  }
+
+  private void validateDuplicateEmail(String email) {
+    if (employeeRepository.findByEmail(email).isPresent()) {
+      throw new IllegalArgumentException("Email already in use");
+    }
+  }
+
+  private Employee getValidateEmployee(long employeeId) {
+    return employeeRepository.findById(employeeId)
+        .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+  }
 
   // 대시보드 공통 메서드
   private LocalDate getDefaultFrom(LocalDate base, TimeUnitType unit, int amount) {

--- a/src/main/java/com/team1/hrbank/domain/file/service/FileMetadataService.java
+++ b/src/main/java/com/team1/hrbank/domain/file/service/FileMetadataService.java
@@ -28,7 +28,7 @@ public class FileMetadataService {
         .orElseThrow(() -> new NoSuchElementException("그런 직원 없음"));
 
     // 기존 이미지 삭제
-    FileMetadata oldMeta = employee.getFileMetaData();
+    FileMetadata oldMeta = employee.getFileMetadata();
     if (oldMeta != null) {
       fileStorageManager.deleteFile(oldMeta.getFilePath()); // 물리적 파일 삭제
       fileMetadataRepository.delete(oldMeta); // DB 삭제


### PR DESCRIPTION
## 관련 이슈
- #20 

## 주요 변경 사항
- 지정된 기간 및 시간 단위로 그룹화된 직원 수 추이 조회
- 파라미터를 제공하지 않으면 최근 12개월 데이터를 월 단위로 반환합니다.
- 기간: 일, 주, 월, 분기, 연도
- 파라미터
   - from: 시작 일시 (기본값: 현재로부터 unit 기준 12개 이전)
   - to: 종료 일시 (기본값: 현재)
   - unit: 시간 단위 (day, week, month, quarter, year, 기본값: month)
- 기간별 x축 계산
- 구간 사이의 입사자 수, 변화량, 증감률 계산