### PR TITLE
hotfix: 쿼리메서드 파라미터 타입 불일치 #75

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/backup/repository/BackupRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/backup/repository/BackupRepository.java
@@ -1,10 +1,12 @@
 package com.team1.hrbank.domain.backup.repository;
 
 import com.team1.hrbank.domain.backup.entity.Backup;
+import com.team1.hrbank.domain.backup.entity.BackupStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BackupRepository extends JpaRepository<Backup, Long>,
     JpaSpecificationExecutor<Backup> {
@@ -13,5 +15,5 @@ public interface BackupRepository extends JpaRepository<Backup, Long>,
   Optional<Backup> findFirstOrderByEndedAtDesc();
 
   @Query("select b from Backup b where b.status = :status order by b.createdAt desc")
-  Optional<Backup> findFirstByStatusOrderByCreatedAtDesc(String status);
+  Optional<Backup> findFirstByStatusOrderByCreatedAtDesc(@Param("status") BackupStatus status);
 }

--- a/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
+++ b/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
@@ -184,7 +184,6 @@ public class BackupService {
 
   @Transactional(readOnly = true)
   public BackupDto findLatest(String status) {
-
     Backup backup = backupRepository.findFirstByStatusOrderByCreatedAtDesc(BackupStatus.valueOf(status))
         .orElseThrow(() -> new IllegalStateException("최신 백업 상태 없음"));
     return backMapper.toDto(backup);

--- a/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
+++ b/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
@@ -184,7 +184,8 @@ public class BackupService {
 
   @Transactional(readOnly = true)
   public BackupDto findLatest(String status) {
-    Backup backup = backupRepository.findFirstByStatusOrderByCreatedAtDesc(status)
+
+    Backup backup = backupRepository.findFirstByStatusOrderByCreatedAtDesc(BackupStatus.valueOf(status))
         .orElseThrow(() -> new IllegalStateException("최신 백업 상태 없음"));
     return backMapper.toDto(backup);
   }


### PR DESCRIPTION
## 관련 이슈
- #75 

## 에러 상황 및 원인
- enum 타입과 String 타입을 비교
	- 상황과 원인이 동일
