### PR TITLE
refactor: Employee 예외를 커스텀 예외로 정의및 적용

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
@@ -189,7 +189,7 @@ public class EmployeeService {
 
     // 중복 확인 후 재귀 호출
     if (employeeRepository.findByEmployeeNumber(employeeNumber).isPresent()) {
-      return createEmployeeNumber(); // 중복 시 다시 생성
+      return createEmployeeNumber(); // 중복 시 다시 생성 1밀리초당 90개의 데이터를 생성하지 않는 이상 이론상 호출되지 않음
     }
 
     return employeeNumber;

--- a/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/service/EmployeeService.java
@@ -20,6 +20,8 @@ import com.team1.hrbank.domain.employee.dto.request.EmployeeCreateRequestDto;
 import com.team1.hrbank.domain.file.service.FileMetadataService;
 import com.team1.hrbank.domain.file.entity.FileMetadata;
 
+import com.team1.hrbank.global.constant.EmployeeErrorCode;
+import com.team1.hrbank.global.error.EmployeeException;
 import java.time.LocalDate;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
@@ -280,13 +282,13 @@ public class EmployeeService {
 
   private void validateDuplicateEmail(String email) {
     if (employeeRepository.findByEmail(email).isPresent()) {
-      throw new IllegalArgumentException("Email already in use");
+      throw new EmployeeException(EmployeeErrorCode.EMPLOYEE_EMAIL_DUPLICATE);
     }
   }
 
   private Employee getValidateEmployee(long employeeId) {
     return employeeRepository.findById(employeeId)
-        .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+        .orElseThrow(() -> new EmployeeException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
   }
 
   // 대시보드 공통 메서드

--- a/src/main/java/com/team1/hrbank/domain/file/service/FileMetadataService.java
+++ b/src/main/java/com/team1/hrbank/domain/file/service/FileMetadataService.java
@@ -7,6 +7,8 @@ import com.team1.hrbank.domain.file.dto.StoredFileInfo;
 import com.team1.hrbank.domain.file.entity.FileMetadata;
 import com.team1.hrbank.domain.file.entity.FileType;
 import com.team1.hrbank.domain.file.repository.FileMetadataRepository;
+import com.team1.hrbank.global.constant.EmployeeErrorCode;
+import com.team1.hrbank.global.error.EmployeeException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,7 @@ public class FileMetadataService {
   @Transactional
   public FileMetadata uploadProfileImage(Long employeeId, MultipartFile file) {
     Employee employee = employeeRepository.findById(employeeId)
-        .orElseThrow(() -> new NoSuchElementException("그런 직원 없음"));
+        .orElseThrow(() -> new EmployeeException(EmployeeErrorCode.EMPLOYEE_NOT_FOUND));
 
     // 기존 이미지 삭제
     FileMetadata oldMeta = employee.getFileMetadata();

--- a/src/main/java/com/team1/hrbank/global/constant/EmployeeErrorCode.java
+++ b/src/main/java/com/team1/hrbank/global/constant/EmployeeErrorCode.java
@@ -1,0 +1,16 @@
+package com.team1.hrbank.global.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmployeeErrorCode implements ErrorCode {
+
+  EMPLOYEE_NOT_FOUND(404, "EMPLOYEE_001", "직원을 찾을 수 없습니다."),
+  EMPLOYEE_EMAIL_DUPLICATE(409, "EMPLOYEE_002", "중복된 이메일입니다.");
+
+  private final int status;
+  private final String message;
+  private final String details;
+}

--- a/src/main/java/com/team1/hrbank/global/error/EmployeeException.java
+++ b/src/main/java/com/team1/hrbank/global/error/EmployeeException.java
@@ -1,0 +1,10 @@
+package com.team1.hrbank.global.error;
+
+import com.team1.hrbank.global.constant.ErrorCode;
+
+public class EmployeeException extends BusinessException {
+
+  public EmployeeException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- #82 
## 주요 변경 사항
- EmployeeService에서 Employee의 Email 중복 확인 및 Employee 객체를 찾는 부분에 커스텀 예외로 대체
- FileMetadataService에서 Employee 객체를 찾는 부분에 커스텀 예외로 대체