### PR TITLE
hotfix : 백업 프로퍼티 이름 불일치 문제 #94

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/backup/mapper/BackupMapper.java
+++ b/src/main/java/com/team1/hrbank/domain/backup/mapper/BackupMapper.java
@@ -3,9 +3,12 @@ package com.team1.hrbank.domain.backup.mapper;
 import com.team1.hrbank.domain.backup.dto.response.BackupDto;
 import com.team1.hrbank.domain.backup.entity.Backup;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface BackupMapper {
 
+
+  @Mapping(target = "startedAt", source = "createdAt")
   BackupDto toDto(Backup backup);
 }

--- a/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
+++ b/src/main/java/com/team1/hrbank/domain/backup/service/BackupService.java
@@ -174,6 +174,10 @@ public class BackupService {
   }
 
   private Pageable createPageable(Integer size, String sortField, String sortDirection) {
+    if ("startedAt".equals(sortField)) {
+      sortField = "createdAt";
+    }
+
     Sort.Direction direction =
         "desc".equalsIgnoreCase(sortDirection) ? Sort.Direction.DESC : Sort.Direction.ASC;
     Sort sort = Sort.by(direction, sortField);


### PR DESCRIPTION
## 관련 이슈
- #94 
## 에러 상황 및 원인
- 파라미터로 받은 startedAt과 엔티티 필드명이 달라서 생긴 문제
  - startedAt, createdAt 매칭
  - backup createdAt,backupDto startedAt 매칭