### PR TITLE
hotfix: 프로필 이미지 등록 오류

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
@@ -21,7 +21,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
   long countByDepartmentId(Long departmentId);
 
   // JOIN FETCH 대체용
-  @EntityGraph(attributePaths = {"department", "fileMetaData"})
+  @EntityGraph(attributePaths = {"department", "fileMetadata"})
   Optional<Employee> findById(Long id);
 
   // 대시보드


### PR DESCRIPTION
- #106  

## 에러 상황 및 원인
- 프로필 이미지 등록 시 오류 발생
   - `the given name [fileMetaData] on this ManagedType [com.team1.hrbank.domain.employee.entity.Employee]] with root cause`
   - fileMetaData → fileMetadata로 변경