### PR TITLE
fix: 직원 관리 수정 시 오류

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/employee/repository/EmployeeRepository.java
@@ -21,7 +21,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
   long countByDepartmentId(Long departmentId);
 
   // JOIN FETCH 대체용
-  @EntityGraph(attributePaths = {"department", "fileMetaData"})
+  @EntityGraph(attributePaths = {"department", "fileMetadata"})
   Optional<Employee> findById(Long id);
 
   // 대시보드


### PR DESCRIPTION
## 관련 이슈
- #104 
## 에러 상황 및 원인
- 직원 수정 시 이메일이 갱신 안되었어도 중복이라고 오류가 뜸
- 직원 수정 시 기존 이미지가 없으면 오류가 발생함
