### PR TITLE
hotfix: 기간 내 이력 수정 건수 조회 불가 오류 수정

### DIFF
--- a/src/main/java/com/team1/hrbank/domain/changelog/dto/request/ChangeLogSearchRequest.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/dto/request/ChangeLogSearchRequest.java
@@ -11,10 +11,11 @@ public record ChangeLogSearchRequest(
         String ipAddress,
         ChangeLogType type,
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        LocalDateTime from,
+        LocalDateTime atFrom,
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        LocalDateTime to,
-        Long lastId,
+        LocalDateTime atTo,
+        Long idAfter,
+        String cursor,
         String sortField,
         String sortDirection,
         Integer size

--- a/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogRepository.java
+++ b/src/main/java/com/team1/hrbank/domain/changelog/repository/ChangeLogRepository.java
@@ -23,7 +23,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
               OR (:to IS NULL AND created_at >= :from)
               OR (created_at BETWEEN :from AND :to)
           )
-          AND (:lastId IS NULL OR id > :lastId)
+          AND (:idAfter IS NULL OR id > :idAfter)
         ORDER BY created_at ASC
         LIMIT :limit
         """, nativeQuery = true)
@@ -34,7 +34,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             @Param("type") String type,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("lastId") Long lastId,
+            @Param("idAfter") Long idAfter,
             @Param("limit") int limit
     );
 
@@ -50,7 +50,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
               OR (:to IS NULL AND created_at >= :from)
               OR (created_at BETWEEN :from AND :to)
           )
-          AND (:lastId IS NULL OR id < :lastId)
+          AND (:idAfter IS NULL OR id < :idAfter)
         ORDER BY created_at DESC
         LIMIT :limit
         """, nativeQuery = true)
@@ -61,7 +61,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             @Param("type") String type,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("lastId") Long lastId,
+            @Param("idAfter") Long idAfter,
             @Param("limit") int limit
     );
 
@@ -77,7 +77,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
               OR (:to IS NULL AND created_at >= :from)
               OR (created_at BETWEEN :from AND :to)
           )
-          AND (:lastId IS NULL OR id > :lastId)
+          AND (:idAfter IS NULL OR id > :idAfter)
         ORDER BY ip_address ASC
         LIMIT :limit
         """, nativeQuery = true)
@@ -88,7 +88,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             @Param("type") String type,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("lastId") Long lastId,
+            @Param("idAfter") Long idAfter,
             @Param("limit") int limit
     );
 
@@ -104,7 +104,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
               OR (:to IS NULL AND created_at >= :from)
               OR (created_at BETWEEN :from AND :to)
           )
-          AND (:lastId IS NULL OR id < :lastId)
+          AND (:idAfter IS NULL OR id < :idAfter)
         ORDER BY ip_address DESC
         LIMIT :limit
         """, nativeQuery = true)
@@ -115,7 +115,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             @Param("type") String type,
             @Param("from") LocalDateTime from,
             @Param("to") LocalDateTime to,
-            @Param("lastId") Long lastId,
+            @Param("idAfter") Long idAfter,
             @Param("limit") int limit
     );
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active : prod
+    active : dev
 
 backup:
   batch:


### PR DESCRIPTION
## 에러 상황 및 원인
- ChangeLogSearchRequest DTO의 atFrom, atTo 필드의 이름이 요구사항과 달라서 문제가 발생하였고, 필드 이름 수정으로 해결함